### PR TITLE
[WIP] connector: implement sending replies

### DIFF
--- a/pkg/connector/capabilities.go
+++ b/pkg/connector/capabilities.go
@@ -139,12 +139,12 @@ func init() {
 
 func (*LinkedInClient) GetCapabilities(ctx context.Context, portal *bridgev2.Portal) *event.RoomFeatures {
 	return &event.RoomFeatures{
-		ID:                  "fi.mau.linkedin.capabilities.2025_01_21",
+		ID:                  "fi.mau.linkedin.capabilities.2025_02_12",
 		Formatting:          formattingCaps,
 		File:                fileCaps,
 		MaxTextLength:       MaxTextLength,
 		LocationMessage:     event.CapLevelDropped,
-		Reply:               event.CapLevelDropped,
+		Reply:               event.CapLevelFullySupported,
 		Edit:                event.CapLevelDropped,
 		Delete:              event.CapLevelDropped,
 		Reaction:            event.CapLevelDropped,

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/rs/zerolog"
+	"go.mau.fi/util/jsontime"
 	"go.mau.fi/util/ptr"
 	"maunium.net/go/mautrix/bridge/status"
 	"maunium.net/go/mautrix/bridgev2"
@@ -363,19 +364,21 @@ func (l *LinkedInClient) HandleMatrixMessage(ctx context.Context, msg *bridgev2.
 		},
 	}
 
-	// if msg.ReplyTo != nil {
-	// 	sendMessagePayload.Message.RenderContentUnions = append(
-	// 		sendMessagePayload.Message.RenderContentUnions,
-	// 		payloadold.RenderContent{
-	// 			RepliedMessageContent: &payloadold.RepliedMessageContent{
-	// 				OriginalSenderUrn:  string(msg.ReplyTo.SenderID),
-	// 				OriginalMessageUrn: string(msg.ReplyTo.ID),
-	// 				OriginalSendAt:     msg.ReplyTo.Timestamp.UnixMilli(),
-	// 				//MessageBody:        "", // todo add at some point
-	// 			},
-	// 		},
-	// 	)
-	// }
+	if msg.ReplyTo != nil {
+		sendMessagePayload.Message.RenderContentUnions = append(
+			sendMessagePayload.Message.RenderContentUnions,
+			linkedingo.SendRenderContent{
+				RepliedMessageContent: &linkedingo.SendRepliedMessage{
+					OriginalSenderURN:  types.NewURN(string(msg.ReplyTo.SenderID)).WithPrefix("urn:li:msg_messagingParticipant:urn:li:fsd_profile"),
+					OriginalSentAt:     jsontime.UnixMilli{Time: msg.ReplyTo.Timestamp},
+					OriginalMessageURN: types.NewURN(string(msg.ReplyTo.ID)),
+					MessageBody: types.AttributedText{
+						Text: "this is the fake content",
+					},
+				},
+			},
+		)
+	}
 
 	// content := msg.Content
 	//

--- a/pkg/linkedingo/messages.go
+++ b/pkg/linkedingo/messages.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/google/uuid"
+	"go.mau.fi/util/jsontime"
 	"go.mau.fi/util/random"
 
 	"go.mau.fi/mautrix-linkedin/pkg/linkedingo/types"
@@ -22,10 +23,10 @@ type SendMessagePayload struct {
 }
 
 type SendMessage struct {
-	Body                SendMessageBody `json:"body,omitempty"`
-	RenderContentUnions []any           `json:"renderContentUnions,omitempty"`
-	ConversationURN     types.URN       `json:"conversationUrn,omitempty"`
-	OriginToken         uuid.UUID       `json:"originToken,omitempty"`
+	Body                SendMessageBody     `json:"body,omitempty"`
+	RenderContentUnions []SendRenderContent `json:"renderContentUnions,omitempty"`
+	ConversationURN     types.URN           `json:"conversationUrn,omitempty"`
+	OriginToken         uuid.UUID           `json:"originToken,omitempty"`
 }
 
 type SendMessageBody struct {
@@ -37,6 +38,17 @@ type SendMessageAttribute struct {
 	Start              int                 `json:"start"`
 	Length             int                 `json:"length"`
 	AttributeKindUnion types.AttributeKind `json:"attributeKindUnion"`
+}
+
+type SendRenderContent struct {
+	RepliedMessageContent *SendRepliedMessage `json:"repliedMessageContent,omitempty"`
+}
+
+type SendRepliedMessage struct {
+	OriginalSenderURN  types.URN            `json:"originalSenderUrn"`
+	OriginalSentAt     jsontime.UnixMilli   `json:"originalSendAt"`
+	OriginalMessageURN types.URN            `json:"originalMessageUrn"`
+	MessageBody        types.AttributedText `json:"messageBody"`
 }
 
 type AttributeType struct {

--- a/pkg/linkedingo/request.go
+++ b/pkg/linkedingo/request.go
@@ -52,6 +52,7 @@ func (a *authedRequest) WithCSRF() *authedRequest {
 
 func (a *authedRequest) WithJSONPayload(payload any) *authedRequest {
 	a.body = bytes.NewReader(exerrors.Must(json.Marshal(payload)))
+	fmt.Printf("%s\n", exerrors.Must(json.Marshal(payload)))
 	return a
 }
 


### PR DESCRIPTION
So, it turns out that LinkedIn requires you to send the previous message content, and LinkedIn renders whatever content is sent.

I think this means that we will have to make our clients send the content of the previous message in the event.

Also, we need a way to signal that replies are only allowed on text messages

Signed-off-by: Sumner Evans <sumner.evans@automattic.com>
