### PR TITLE
Fix type of identifiers column during migration

### DIFF
--- a/cmd/mautrix-linkedin/legacymigrate.sql
+++ b/cmd/mautrix-linkedin/legacymigrate.sql
@@ -28,7 +28,7 @@ SELECT
     false, -- avatar_set (need to set it on the new case-insensitive ghost mxid)
     false, -- contact_info_set (need to set it on the new case-insensitive ghost mxid)
     false, -- is_bot
-    '["linkedin:' || li_member_urn || '"]', -- identifiers
+    ('["linkedin:' || li_member_urn || '"]')::jsonb, -- identifiers
     '{}' -- metadata
 FROM puppet_old;
 


### PR DESCRIPTION
Hello, I tried updating from the (discontinued?) [`ghcr.io/beeper/linkedin:latest` container](https://github.com/beeper/linkedin) to `dock.mau.dev/mautrix/linkedin:latest` (is that supported?) and run into the following error when starting the bridge:

```
"pq: column \"identifiers\" is of type jsonb but expression is of type text"
```

The `ghost.identifiers` column has the type `jsonb`:
https://github.com/mautrix/go/blob/27769dfc98bebdcec16bb2293029904109a2b9df/bridgev2/database/upgrades/00-latest.sql#L80

But this expression retuned `text`:
```
mautrix_linkedin=# select pg_typeof('["linkedin:' || li_member_urn || '"]') from puppet;
 pg_typeof
-----------
 text
```
