### PR TITLE
linkedingo: fix message delivery

### DIFF
--- a/pkg/linkedingo/client.go
+++ b/pkg/linkedingo/client.go
@@ -33,6 +33,7 @@ const OSName = "Linux"
 const SecCHPlatform = `"` + OSName + `"`
 const SecCHMobile = "?0"
 const SecCHPrefersColorScheme = "light"
+const ServiceVersion = "1.13.36969"
 
 type Client struct {
 	http          *http.Client
@@ -55,7 +56,7 @@ func NewClient(ctx context.Context, userEntityURN URN, jar *StringCookieJar, pag
 	log := zerolog.Ctx(ctx)
 	if xLiTrack == "" {
 		log.Warn().Msg("x-li-track is empty, using default")
-		xLiTrack = `{"clientVersion":"1.13.32603","mpVersion":"1.13.32603","osName":"web","timezoneOffset":-6,"timezone":"America/Denver","deviceFormFactor":"DESKTOP","mpName":"voyager-web","displayDensity":2,"displayWidth":2880,"displayHeight":1800}`
+		xLiTrack = `{"clientVersion":"` + ServiceVersion + `","mpVersion":"` + ServiceVersion + `","osName":"web","deviceFormFactor":"DESKTOP","mpName":"voyager-web","displayDensity":2,"displayWidth":2880,"displayHeight":1800}`
 	}
 	if pageInstance == "" {
 		log.Warn().Msg("pageInstance is empty, using default")
@@ -69,7 +70,7 @@ func NewClient(ctx context.Context, userEntityURN URN, jar *StringCookieJar, pag
 	serviceVersion, _ := trackingData["mpVersion"].(string)
 	if serviceVersion == "" {
 		log.Warn().Msg("mpVersion is empty, using default")
-		serviceVersion = "1.13.32603"
+		serviceVersion = ServiceVersion
 	}
 	return &Client{
 		userEntityURN:     userEntityURN,

--- a/pkg/linkedingo/push.go
+++ b/pkg/linkedingo/push.go
@@ -18,7 +18,7 @@ func (c *Client) RegisterAndroidPush(ctx context.Context, token string) error {
 		return fmt.Errorf("failed to generate device id: %w", err)
 	}
 	trackHeader := fmt.Sprintf(
-		`{"osName":"Android OS","osVersion":"34","clientVersion":"4.1.1059","clientMinorVersion":196700,"model":"Google_Pixel 5a","displayDensity":2.625,"displayWidth":1080,"displayHeight":2201,"dpi":"xhdpi","deviceType":"android","appId":"com.linkedin.android","deviceId":"%s","timezoneOffset":0,"timezone":"Europe\/London","storeId":"us_googleplay","isAdTrackingLimited":false,"mpName":"voyager-android","mpVersion":"2.137.73"}`,
+		`{"osName":"Android OS","osVersion":"35","clientVersion":"4.1.1087.2","clientMinorVersion":199502,"model":"Google_Pixel 5a","displayDensity":2.625,"displayWidth":1080,"displayHeight":2201,"dpi":"xhdpi","deviceType":"android","appId":"com.linkedin.android","deviceId":"%s","storeId":"us_googleplay","isAdTrackingLimited":true,"mpName":"voyager-android","mpVersion":"2.165.98"}`,
 		deviceId.String(),
 	)
 

--- a/pkg/linkedingo/request.go
+++ b/pkg/linkedingo/request.go
@@ -134,13 +134,7 @@ func (a *authedRequest) WithContentType(contentType string) *authedRequest {
 func (a *authedRequest) WithXLIHeaders() *authedRequest {
 	return a.
 		WithHeader("Referer", linkedInMessagingBaseURL+"/").
-		WithHeader("X-LI-Accept", contentTypeJSONLinkedInNormalized).
 		WithHeader("X-LI-Page-Instance", a.client.pageInstance).
-		WithHeader("X-LI-Query-Accept", contentTypeGraphQL).
-		WithHeader("X-LI-Query-Map", realtimeQueryMap).
-		WithHeader("X-LI-Realtime-Session", a.client.realtimeSessionID.String()).
-		WithHeader("X-LI-Recipe-Accept", contentTypeJSONLinkedInNormalized).
-		WithHeader("X-LI-Recipe-Map", realtimeRecipeMap).
 		WithHeader("X-LI-Track", a.client.xLITrack).
 		WithHeader("X-RestLI-Protocol-Version", "2.0.0")
 }
@@ -151,6 +145,12 @@ func (a *authedRequest) WithRealtimeConnectHeaders() *authedRequest {
 		WithHeader("Sec-Fetch-Dest", "empty").
 		WithHeader("Sec-Fetch-Mode", "cors").
 		WithHeader("Sec-Fetch-Site", "same-origin").
+		WithHeader("X-LI-Accept", contentTypeJSONLinkedInNormalized).
+		WithHeader("X-LI-Query-Accept", contentTypeGraphQL).
+		WithHeader("X-LI-Query-Map", realtimeQueryMap).
+		WithHeader("X-LI-Recipe-Accept", contentTypeJSONLinkedInNormalized).
+		WithHeader("X-LI-Recipe-Map", realtimeRecipeMap).
+		WithHeader("X-LI-Realtime-Session", a.client.realtimeSessionID.String()).
 		WithXLIHeaders()
 }
 

--- a/pkg/linkedingo/x-li-query-map.json
+++ b/pkg/linkedingo/x-li-query-map.json
@@ -96,7 +96,7 @@
 			"extensions": {}
 		},
 		"liveVideoPostTopic": {
-			"queryId": "liveVideoVoyagerFeedDashLiveUpdatesRealtimeDecoration.96dba07244496804ecba6faffe521809",
+			"queryId": "liveVideoVoyagerFeedDashLiveUpdatesRealtimeDecoration.8a49ee0fcd7639164d4d8ffc3d3aa75d",
 			"variables": {},
 			"extensions": {}
 		},
@@ -125,18 +125,13 @@
 			"variables": {},
 			"extensions": {}
 		},
-		"eventToastsTopic": {
-			"queryId": "voyagerEventsDashProfessionalEventsRealtimeResource.6b42abd3511e267e84a6765257deea50",
-			"variables": {},
-			"extensions": {}
-		},
 		"coachStreamingResponsesTopic": {
-			"queryId": "voyagerCoachDashGaiRealtimeDecoration.efc252713e6b496038bad63527626891",
+			"queryId": "voyagerCoachDashGaiRealtimeDecoration.cd698d3c9740c1f159c8c25819903bfb",
 			"variables": {},
 			"extensions": {}
 		},
 		"realtimeSearchResultClustersTopic": {
-			"queryId": "voyagerSearchDashRealtimeDecoration.892a35c92a98bb685e62f89577c5c1e8",
+			"queryId": "voyagerSearchDashRealtimeDecoration.86ac87ad3bc1ac95ff6e66b318283658",
 			"variables": {},
 			"extensions": {}
 		},

--- a/pkg/linkedingo/x-li-recipe-map.json
+++ b/pkg/linkedingo/x-li-recipe-map.json
@@ -1,6 +1,6 @@
 {
 	"inAppAlertsTopic": "com.linkedin.voyager.dash.deco.identity.notifications.InAppAlert-52",
-	"professionalEventsTopic": "com.linkedin.voyager.dash.deco.events.ProfessionalEventDetailPage-61",
+	"professionalEventsTopic": "com.linkedin.voyager.dash.deco.events.ProfessionalEventDetailPage-62",
 	"tabBadgeUpdateTopic": "com.linkedin.voyager.dash.deco.notifications.RealtimeBadgingItemCountsEvent-1",
 	"topCardLiveVideoTopic": "com.linkedin.voyager.dash.deco.video.TopCardLiveVideo-10"
 }


### PR DESCRIPTION
This commit fixes a regression and updated headers to ensure consistency with the latest LinkedIn web client.

This should fix all Voyager API requests including sending/editing/removing messages, media and reactions that were previously inadvertently broken due to malformed request headers.

Note: the updated FCM registration was dumped from the latest Android app
