### PR TITLE
login: store the browser's user agent and send it with requests

### DIFF
--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -81,6 +81,7 @@ func NewLinkedInClient(ctx context.Context, lc *LinkedInConnector, login *bridge
 		cookies,
 		meta.XLIPageInstance,
 		meta.XLITrack,
+		meta.UserAgent,
 		meta.ConversationsSyncToken,
 		linkedingo.Handlers{
 			Heartbeat: func(ctx context.Context) {

--- a/pkg/connector/dbmeta.go
+++ b/pkg/connector/dbmeta.go
@@ -40,6 +40,7 @@ type UserLoginMetadata struct {
 	Cookies                *linkedingo.StringCookieJar `json:"cookies,omitempty"`
 	XLITrack               string                      `json:"x_li_track,omitempty"`
 	XLIPageInstance        string                      `json:"x_li_page_instance,omitempty"`
+	UserAgent              string                      `json:"user_agent,omitempty"`
 	ConversationsSyncToken string                      `json:"conversations_sync_token,omitempty"`
 }
 

--- a/pkg/connector/login.go
+++ b/pkg/connector/login.go
@@ -60,6 +60,7 @@ var (
 	CookieLoginCookieHeaderField    = "fi.mau.linkedin.login.cookie_header"
 	CookieLoginXLITrackField        = "fi.mau.linkedin.login.x_li_track"
 	CookieLoginXLIPageInstanceField = "fi.mau.linkedin.login.x_li_page_instance"
+	CookieLoginUserAgentField       = "fi.mau.linkedin.login.user_agent"
 )
 
 var _ bridgev2.LoginProcessCookies = (*CookieLogin)(nil)
@@ -114,6 +115,20 @@ func (c *CookieLogin) Start(ctx context.Context) (*bridgev2.LoginStep, error) {
 					},
 					Pattern: "urn:li:page",
 				},
+				{
+					// Optional so existing login flows keep working: when it is
+					// absent the client falls back to the compile-time default
+					// browser identity, which is the pre-existing behaviour.
+					ID:       CookieLoginUserAgentField,
+					Required: false,
+					Sources: []bridgev2.LoginCookieFieldSource{
+						{
+							Type:            bridgev2.LoginCookieTypeRequestHeader,
+							Name:            "User-Agent",
+							RequestURLRegex: "https://www.linkedin.com",
+						},
+					},
+				},
 			},
 		},
 	}, nil
@@ -131,8 +146,9 @@ func (c *CookieLogin) SubmitCookies(ctx context.Context, cookies map[string]stri
 
 	pageInstance := cookies[CookieLoginXLIPageInstanceField]
 	xLiTrack := cookies[CookieLoginXLITrackField]
+	userAgent := cookies[CookieLoginUserAgentField]
 
-	loginClient := linkedingo.NewClient(ctx, linkedingo.NewURN(""), jar, pageInstance, xLiTrack, "", linkedingo.Handlers{})
+	loginClient := linkedingo.NewClient(ctx, linkedingo.NewURN(""), jar, pageInstance, xLiTrack, userAgent, "", linkedingo.Handlers{})
 	profile, err := loginClient.GetCurrentUserProfile(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get current user profile: %w", err)
@@ -147,6 +163,7 @@ func (c *CookieLogin) SubmitCookies(ctx context.Context, cookies map[string]stri
 				Cookies:         jar,
 				XLIPageInstance: pageInstance,
 				XLITrack:        xLiTrack,
+				UserAgent:       userAgent,
 			},
 			RemoteName: remoteName,
 			RemoteProfile: status.RemoteProfile{

--- a/pkg/linkedingo/client.go
+++ b/pkg/linkedingo/client.go
@@ -20,7 +20,10 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"regexp"
+	"strings"
 	"sync"
 
 	"github.com/google/uuid"
@@ -36,6 +39,43 @@ const OSName = "Linux"
 const SecCHPlatform = `"` + OSName + `"`
 const SecCHMobile = "?0"
 const SecCHPrefersColorScheme = "light"
+
+var chromeVersionRegex = regexp.MustCompile(`Chrome/(\d+)`)
+
+// browserHintsFromUserAgent derives the sec-ch-ua and sec-ch-ua-platform
+// values that a real browser would send alongside the given user agent.
+//
+// LinkedIn cross-checks these against each other and against the session the
+// cookies were issued to. Sending a stored user agent while leaving the client
+// hints on their compile-time defaults produces a request that claims two
+// different browsers at once, which is worse than not overriding at all.
+//
+// Returns ok=false if the user agent isn't recognisably Chromium, in which case
+// callers should keep the defaults rather than emit a half-populated set.
+func browserHintsFromUserAgent(userAgent string) (secCHUA, secCHUAPlatform string, ok bool) {
+	match := chromeVersionRegex.FindStringSubmatch(userAgent)
+	if match == nil {
+		return "", "", false
+	}
+	version := match[1]
+
+	platform := "Linux"
+	switch {
+	case strings.Contains(userAgent, "Macintosh"):
+		platform = "macOS"
+	case strings.Contains(userAgent, "Windows"):
+		platform = "Windows"
+	case strings.Contains(userAgent, "Android"):
+		platform = "Android"
+	case strings.Contains(userAgent, "CrOS"):
+		platform = "Chrome OS"
+	case strings.Contains(userAgent, "iPhone"), strings.Contains(userAgent, "iPad"):
+		platform = "iOS"
+	}
+
+	secCHUA = fmt.Sprintf(`"Chromium";v="%s", "Google Chrome";v="%s", "Not-A.Brand";v="99"`, version, version)
+	return secCHUA, fmt.Sprintf("%q", platform), true
+}
 const ServiceVersion = "1.13.40953"
 const defaultXLiTrack = `{"clientVersion":"` + ServiceVersion + `","mpVersion":"` + ServiceVersion + `","osName":"web","deviceFormFactor":"DESKTOP","mpName":"voyager-web","displayDensity":2,"displayWidth":2880,"displayHeight":1800}`
 
@@ -54,10 +94,14 @@ type Client struct {
 	xLITrack       string
 	serviceVersion string
 
+	userAgent       string
+	secCHUA         string
+	secCHUAPlatform string
+
 	conversationsSyncToken string
 }
 
-func NewClient(ctx context.Context, userEntityURN URN, jar *StringCookieJar, pageInstance, xLiTrack, conversationsSyncToken string, handlers Handlers) *Client {
+func NewClient(ctx context.Context, userEntityURN URN, jar *StringCookieJar, pageInstance, xLiTrack, userAgent, conversationsSyncToken string, handlers Handlers) *Client {
 	log := zerolog.Ctx(ctx)
 	if xLiTrack == "" {
 		log.Warn().Msg("x-li-track is empty, using default")
@@ -86,12 +130,27 @@ func NewClient(ctx context.Context, userEntityURN URN, jar *StringCookieJar, pag
 		pageInstance = "urn:li:page:d_flagship3_messaging_conversation_detail;" + base64.StdEncoding.EncodeToString(random.Bytes(16))
 	}
 
+	// The cookies were issued to a specific browser. Keep identifying ourselves
+	// as that browser rather than as the compile-time default, and only do so if
+	// we can derive a matching client-hint set — a stored user agent paired with
+	// mismatched hints is a stronger inconsistency signal than the defaults.
+	secCHUA, secCHUAPlatform, ok := browserHintsFromUserAgent(userAgent)
+	if userAgent != "" && !ok {
+		log.Warn().Msg("stored user agent is not recognisably Chromium, using default browser identity")
+	}
+	if !ok {
+		userAgent, secCHUA, secCHUAPlatform = UserAgent, SecCHUserAgent, SecCHPlatform
+	}
+
 	cli := &Client{
 		userEntityURN:          userEntityURN,
 		jar:                    jar,
 		pageInstance:           pageInstance,
 		xLITrack:               xLiTrack,
 		serviceVersion:         serviceVersion,
+		userAgent:              userAgent,
+		secCHUA:                secCHUA,
+		secCHUAPlatform:        secCHUAPlatform,
 		realtimeSessionID:      uuid.New(),
 		handlers:               handlers,
 		conversationsSyncToken: conversationsSyncToken,

--- a/pkg/linkedingo/client.go
+++ b/pkg/linkedingo/client.go
@@ -42,39 +42,72 @@ const SecCHPrefersColorScheme = "light"
 
 var chromeVersionRegex = regexp.MustCompile(`Chrome/(\d+)`)
 
-// browserHintsFromUserAgent derives the sec-ch-ua and sec-ch-ua-platform
-// values that a real browser would send alongside the given user agent.
-//
+// browserIdentity is the set of headers by which the client identifies itself.
 // LinkedIn cross-checks these against each other and against the session the
-// cookies were issued to. Sending a stored user agent while leaving the client
-// hints on their compile-time defaults produces a request that claims two
-// different browsers at once, which is worse than not overriding at all.
-//
-// Returns ok=false if the user agent isn't recognisably Chromium, in which case
-// callers should keep the defaults rather than emit a half-populated set.
-func browserHintsFromUserAgent(userAgent string) (secCHUA, secCHUAPlatform string, ok bool) {
+// cookies were issued to, so they always have to describe one browser.
+type browserIdentity struct {
+	userAgent string
+
+	// User-Agent Client Hints are a Chromium feature: Firefox and Safari send
+	// none of the sec-ch-* headers. When the identity is not Chromium these are
+	// unset and the headers are omitted entirely, because a Firefox user agent
+	// arriving with Chromium client hints is its own contradiction.
+	sendClientHints bool
+	secCHUA         string
+	secCHUAMobile   string
+	secCHUAPlatform string
+}
+
+func defaultBrowserIdentity() browserIdentity {
+	return browserIdentity{
+		userAgent:       UserAgent,
+		sendClientHints: true,
+		secCHUA:         SecCHUserAgent,
+		secCHUAMobile:   SecCHMobile,
+		secCHUAPlatform: SecCHPlatform,
+	}
+}
+
+// browserIdentityFromUserAgent builds a self-consistent identity from a stored
+// user agent. An empty user agent yields the compile-time default; a
+// non-Chromium one is used as-is with client hints suppressed.
+func browserIdentityFromUserAgent(userAgent string) browserIdentity {
+	if userAgent == "" {
+		return defaultBrowserIdentity()
+	}
+
+	identity := browserIdentity{userAgent: userAgent}
 	match := chromeVersionRegex.FindStringSubmatch(userAgent)
 	if match == nil {
-		return "", "", false
+		return identity
 	}
 	version := match[1]
 
-	platform := "Linux"
+	identity.sendClientHints = true
+	identity.secCHUA = fmt.Sprintf(`"Chromium";v="%s", "Google Chrome";v="%s", "Not-A.Brand";v="99"`, version, version)
+	identity.secCHUAMobile = SecCHMobile
+	if strings.Contains(userAgent, "Mobile") || strings.Contains(userAgent, "Android") {
+		identity.secCHUAMobile = "?1"
+	}
+	identity.secCHUAPlatform = fmt.Sprintf("%q", platformFromUserAgent(userAgent))
+	return identity
+}
+
+func platformFromUserAgent(userAgent string) string {
 	switch {
 	case strings.Contains(userAgent, "Macintosh"):
-		platform = "macOS"
+		return "macOS"
 	case strings.Contains(userAgent, "Windows"):
-		platform = "Windows"
+		return "Windows"
 	case strings.Contains(userAgent, "Android"):
-		platform = "Android"
+		return "Android"
 	case strings.Contains(userAgent, "CrOS"):
-		platform = "Chrome OS"
+		return "Chrome OS"
 	case strings.Contains(userAgent, "iPhone"), strings.Contains(userAgent, "iPad"):
-		platform = "iOS"
+		return "iOS"
+	default:
+		return "Linux"
 	}
-
-	secCHUA = fmt.Sprintf(`"Chromium";v="%s", "Google Chrome";v="%s", "Not-A.Brand";v="99"`, version, version)
-	return secCHUA, fmt.Sprintf("%q", platform), true
 }
 const ServiceVersion = "1.13.40953"
 const defaultXLiTrack = `{"clientVersion":"` + ServiceVersion + `","mpVersion":"` + ServiceVersion + `","osName":"web","deviceFormFactor":"DESKTOP","mpName":"voyager-web","displayDensity":2,"displayWidth":2880,"displayHeight":1800}`
@@ -94,9 +127,7 @@ type Client struct {
 	xLITrack       string
 	serviceVersion string
 
-	userAgent       string
-	secCHUA         string
-	secCHUAPlatform string
+	identity browserIdentity
 
 	conversationsSyncToken string
 }
@@ -130,16 +161,13 @@ func NewClient(ctx context.Context, userEntityURN URN, jar *StringCookieJar, pag
 		pageInstance = "urn:li:page:d_flagship3_messaging_conversation_detail;" + base64.StdEncoding.EncodeToString(random.Bytes(16))
 	}
 
-	// The cookies were issued to a specific browser. Keep identifying ourselves
-	// as that browser rather than as the compile-time default, and only do so if
-	// we can derive a matching client-hint set — a stored user agent paired with
-	// mismatched hints is a stronger inconsistency signal than the defaults.
-	secCHUA, secCHUAPlatform, ok := browserHintsFromUserAgent(userAgent)
-	if userAgent != "" && !ok {
-		log.Warn().Msg("stored user agent is not recognisably Chromium, using default browser identity")
-	}
-	if !ok {
-		userAgent, secCHUA, secCHUAPlatform = UserAgent, SecCHUserAgent, SecCHPlatform
+	// The cookies were issued to a specific browser, so keep identifying
+	// ourselves as that browser rather than as the compile-time default.
+	identity := browserIdentityFromUserAgent(userAgent)
+	if userAgent == "" {
+		log.Warn().Msg("no user agent stored for this login, using default browser identity")
+	} else if !identity.sendClientHints {
+		log.Debug().Msg("stored user agent is not Chromium, omitting client hint headers")
 	}
 
 	cli := &Client{
@@ -148,9 +176,7 @@ func NewClient(ctx context.Context, userEntityURN URN, jar *StringCookieJar, pag
 		pageInstance:           pageInstance,
 		xLITrack:               xLiTrack,
 		serviceVersion:         serviceVersion,
-		userAgent:              userAgent,
-		secCHUA:                secCHUA,
-		secCHUAPlatform:        secCHUAPlatform,
+		identity:               identity,
 		realtimeSessionID:      uuid.New(),
 		handlers:               handlers,
 		conversationsSyncToken: conversationsSyncToken,

--- a/pkg/linkedingo/client_internal_test.go
+++ b/pkg/linkedingo/client_internal_test.go
@@ -22,56 +22,60 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestBrowserHintsFromUserAgent(t *testing.T) {
-	tests := []struct {
-		name             string
-		userAgent        string
-		expectedOK       bool
-		expectedUA       string
-		expectedPlatform string
-	}{
-		{
-			name:             "chrome on macos",
-			userAgent:        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36",
-			expectedOK:       true,
-			expectedUA:       `"Chromium";v="151", "Google Chrome";v="151", "Not-A.Brand";v="99"`,
-			expectedPlatform: `"macOS"`,
-		},
-		{
-			name:             "chrome on linux",
-			userAgent:        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36",
-			expectedOK:       true,
-			expectedUA:       `"Chromium";v="141", "Google Chrome";v="141", "Not-A.Brand";v="99"`,
-			expectedPlatform: `"Linux"`,
-		},
-		{
-			name:             "chrome on windows",
-			userAgent:        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36",
-			expectedOK:       true,
-			expectedUA:       `"Chromium";v="150", "Google Chrome";v="150", "Not-A.Brand";v="99"`,
-			expectedPlatform: `"Windows"`,
-		},
-		{
-			name:       "non-chromium is rejected rather than half-populated",
-			userAgent:  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:130.0) Gecko/20100101 Firefox/130.0",
-			expectedOK: false,
-		},
-		{
-			name:       "empty",
-			userAgent:  "",
-			expectedOK: false,
-		},
-	}
+func TestBrowserIdentityFromUserAgent(t *testing.T) {
+	const (
+		chromeMacOS   = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36"
+		chromeLinux   = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36"
+		chromeWindows = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36"
+		chromeAndroid = "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Mobile Safari/537.36"
+		edgeWindows   = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36 Edg/150.0.0.0"
+		firefoxMacOS  = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:130.0) Gecko/20100101 Firefox/130.0"
+		safariMacOS   = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15"
+	)
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			secCHUA, platform, ok := browserHintsFromUserAgent(test.userAgent)
-			assert.Equal(t, test.expectedOK, ok)
-			if !test.expectedOK {
-				return
-			}
-			assert.Equal(t, test.expectedUA, secCHUA)
-			assert.Equal(t, test.expectedPlatform, platform)
-		})
-	}
+	t.Run("empty falls back to the compile-time default", func(t *testing.T) {
+		identity := browserIdentityFromUserAgent("")
+		assert.Equal(t, defaultBrowserIdentity(), identity)
+		assert.True(t, identity.sendClientHints)
+	})
+
+	t.Run("chromium derives matching hints", func(t *testing.T) {
+		tests := []struct {
+			name             string
+			userAgent        string
+			expectedUA       string
+			expectedPlatform string
+			expectedMobile   string
+		}{
+			{"macos", chromeMacOS, `"Chromium";v="151", "Google Chrome";v="151", "Not-A.Brand";v="99"`, `"macOS"`, "?0"},
+			{"linux", chromeLinux, `"Chromium";v="141", "Google Chrome";v="141", "Not-A.Brand";v="99"`, `"Linux"`, "?0"},
+			{"windows", chromeWindows, `"Chromium";v="150", "Google Chrome";v="150", "Not-A.Brand";v="99"`, `"Windows"`, "?0"},
+			{"android is mobile", chromeAndroid, `"Chromium";v="150", "Google Chrome";v="150", "Not-A.Brand";v="99"`, `"Android"`, "?1"},
+			{"edge is chromium", edgeWindows, `"Chromium";v="150", "Google Chrome";v="150", "Not-A.Brand";v="99"`, `"Windows"`, "?0"},
+		}
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				identity := browserIdentityFromUserAgent(test.userAgent)
+				assert.Equal(t, test.userAgent, identity.userAgent)
+				assert.True(t, identity.sendClientHints)
+				assert.Equal(t, test.expectedUA, identity.secCHUA)
+				assert.Equal(t, test.expectedPlatform, identity.secCHUAPlatform)
+				assert.Equal(t, test.expectedMobile, identity.secCHUAMobile)
+			})
+		}
+	})
+
+	// Firefox and Safari send no sec-ch-* headers at all, so the user agent is
+	// kept and the hints are suppressed rather than filled in with Chromium
+	// values, which would contradict the user agent.
+	t.Run("non-chromium keeps the user agent and omits client hints", func(t *testing.T) {
+		for _, userAgent := range []string{firefoxMacOS, safariMacOS} {
+			identity := browserIdentityFromUserAgent(userAgent)
+			assert.Equal(t, userAgent, identity.userAgent)
+			assert.False(t, identity.sendClientHints)
+			assert.Empty(t, identity.secCHUA)
+			assert.Empty(t, identity.secCHUAPlatform)
+			assert.Empty(t, identity.secCHUAMobile)
+		}
+	})
 }

--- a/pkg/linkedingo/client_internal_test.go
+++ b/pkg/linkedingo/client_internal_test.go
@@ -17,9 +17,12 @@
 package linkedingo
 
 import (
+	"context"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBrowserIdentityFromUserAgent(t *testing.T) {
@@ -77,5 +80,47 @@ func TestBrowserIdentityFromUserAgent(t *testing.T) {
 			assert.Empty(t, identity.secCHUAPlatform)
 			assert.Empty(t, identity.secCHUAMobile)
 		}
+	})
+}
+
+// The identity only matters if it reaches the wire, so assert on the headers an
+// actual request carries rather than on the derived struct alone.
+func TestRequestHeadersMatchStoredUserAgent(t *testing.T) {
+	newClientWithUserAgent := func(userAgent string) *Client {
+		return NewClient(
+			context.Background(), NewURN(""), NewEmptyStringCookieJar(),
+			"", "", userAgent, "", Handlers{},
+		)
+	}
+
+	t.Run("chromium sends client hints matching its user agent", func(t *testing.T) {
+		const userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36"
+		req := newClientWithUserAgent(userAgent).newAuthedRequest(http.MethodGet, "https://www.linkedin.com/voyager/api/me")
+		require.NoError(t, req.parseErr)
+
+		assert.Equal(t, userAgent, req.header.Get("User-Agent"))
+		assert.Equal(t, `"Chromium";v="151", "Google Chrome";v="151", "Not-A.Brand";v="99"`, req.header.Get("sec-ch-ua"))
+		assert.Equal(t, `"macOS"`, req.header.Get("sec-ch-ua-platform"))
+		assert.Equal(t, "?0", req.header.Get("sec-ch-ua-mobile"))
+	})
+
+	t.Run("firefox sends no client hints at all", func(t *testing.T) {
+		const userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:130.0) Gecko/20100101 Firefox/130.0"
+		req := newClientWithUserAgent(userAgent).newAuthedRequest(http.MethodGet, "https://www.linkedin.com/voyager/api/me")
+		require.NoError(t, req.parseErr)
+
+		assert.Equal(t, userAgent, req.header.Get("User-Agent"))
+		for _, header := range []string{"sec-ch-ua", "sec-ch-ua-platform", "sec-ch-ua-mobile", "sec-ch-prefers-color-scheme"} {
+			assert.Empty(t, req.header.Get(header), "%s must not be sent for a non-Chromium user agent", header)
+		}
+	})
+
+	t.Run("no stored user agent keeps the compile-time identity", func(t *testing.T) {
+		req := newClientWithUserAgent("").newAuthedRequest(http.MethodGet, "https://www.linkedin.com/voyager/api/me")
+		require.NoError(t, req.parseErr)
+
+		assert.Equal(t, UserAgent, req.header.Get("User-Agent"))
+		assert.Equal(t, SecCHUserAgent, req.header.Get("sec-ch-ua"))
+		assert.Equal(t, SecCHPlatform, req.header.Get("sec-ch-ua-platform"))
 	})
 }

--- a/pkg/linkedingo/client_internal_test.go
+++ b/pkg/linkedingo/client_internal_test.go
@@ -1,0 +1,77 @@
+// mautrix-linkedin - A Matrix-LinkedIn puppeting bridge.
+// Copyright (C) 2025 Sumner Evans
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package linkedingo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBrowserHintsFromUserAgent(t *testing.T) {
+	tests := []struct {
+		name             string
+		userAgent        string
+		expectedOK       bool
+		expectedUA       string
+		expectedPlatform string
+	}{
+		{
+			name:             "chrome on macos",
+			userAgent:        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36",
+			expectedOK:       true,
+			expectedUA:       `"Chromium";v="151", "Google Chrome";v="151", "Not-A.Brand";v="99"`,
+			expectedPlatform: `"macOS"`,
+		},
+		{
+			name:             "chrome on linux",
+			userAgent:        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36",
+			expectedOK:       true,
+			expectedUA:       `"Chromium";v="141", "Google Chrome";v="141", "Not-A.Brand";v="99"`,
+			expectedPlatform: `"Linux"`,
+		},
+		{
+			name:             "chrome on windows",
+			userAgent:        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36",
+			expectedOK:       true,
+			expectedUA:       `"Chromium";v="150", "Google Chrome";v="150", "Not-A.Brand";v="99"`,
+			expectedPlatform: `"Windows"`,
+		},
+		{
+			name:       "non-chromium is rejected rather than half-populated",
+			userAgent:  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:130.0) Gecko/20100101 Firefox/130.0",
+			expectedOK: false,
+		},
+		{
+			name:       "empty",
+			userAgent:  "",
+			expectedOK: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			secCHUA, platform, ok := browserHintsFromUserAgent(test.userAgent)
+			assert.Equal(t, test.expectedOK, ok)
+			if !test.expectedOK {
+				return
+			}
+			assert.Equal(t, test.expectedUA, secCHUA)
+			assert.Equal(t, test.expectedPlatform, platform)
+		})
+	}
+}

--- a/pkg/linkedingo/request.go
+++ b/pkg/linkedingo/request.go
@@ -81,12 +81,16 @@ func (c *Client) newAuthedRequest(method, urlStr string) *authedRequest {
 	// Add default headers for every request. The browser identity comes from the
 	// client so it matches the browser the cookies were issued to; NewClient
 	// falls back to the compile-time defaults when no user agent was stored.
-	ar.header.Add("User-Agent", c.userAgent)
+	ar.header.Add("User-Agent", c.identity.userAgent)
 	ar.header.Add("Accept-Language", "en-US,en;q=0.9")
-	ar.header.Add("sec-ch-prefers-color-scheme", SecCHPrefersColorScheme)
-	ar.header.Add("sec-ch-ua", c.secCHUA)
-	ar.header.Add("sec-ch-ua-mobile", SecCHMobile)
-	ar.header.Add("sec-ch-ua-platform", c.secCHUAPlatform)
+	// sec-ch-* are Chromium-only. Omit them entirely for other browsers rather
+	// than sending Chromium hints alongside a non-Chromium user agent.
+	if c.identity.sendClientHints {
+		ar.header.Add("sec-ch-prefers-color-scheme", SecCHPrefersColorScheme)
+		ar.header.Add("sec-ch-ua", c.identity.secCHUA)
+		ar.header.Add("sec-ch-ua-mobile", c.identity.secCHUAMobile)
+		ar.header.Add("sec-ch-ua-platform", c.identity.secCHUAPlatform)
+	}
 
 	return &ar
 }

--- a/pkg/linkedingo/request.go
+++ b/pkg/linkedingo/request.go
@@ -78,13 +78,15 @@ func (c *Client) newAuthedRequest(method, urlStr string) *authedRequest {
 		ar.queryParams = url.Values{}
 	}
 
-	// Add default headers for every request
-	ar.header.Add("User-Agent", UserAgent)
+	// Add default headers for every request. The browser identity comes from the
+	// client so it matches the browser the cookies were issued to; NewClient
+	// falls back to the compile-time defaults when no user agent was stored.
+	ar.header.Add("User-Agent", c.userAgent)
 	ar.header.Add("Accept-Language", "en-US,en;q=0.9")
 	ar.header.Add("sec-ch-prefers-color-scheme", SecCHPrefersColorScheme)
-	ar.header.Add("sec-ch-ua", SecCHUserAgent)
+	ar.header.Add("sec-ch-ua", c.secCHUA)
 	ar.header.Add("sec-ch-ua-mobile", SecCHMobile)
-	ar.header.Add("sec-ch-ua-platform", SecCHPlatform)
+	ar.header.Add("sec-ch-ua-platform", c.secCHUAPlatform)
 
 	return &ar
 }


### PR DESCRIPTION
### Problem

Cookies handed to the bridge are bound to the browser that created them, but every request goes out with the compile-time identity in `pkg/linkedingo/client.go`:

```go
const ChromeVersion = "141"
const UserAgent = "Mozilla/5.0 (X11; Linux x86_64) … Chrome/141.0.0.0 …"
const OSName = "Linux"
```

`X-LI-Track` and `X-LI-Page-Instance` are already captured at login and sent as-is. `User-Agent`, `sec-ch-ua` and `sec-ch-ua-platform` are not. So a session created by Chrome 151 on macOS produces requests that say:

| Signal | Claims |
| --- | --- |
| `User-Agent` / `sec-ch-ua-platform` | Chrome 141, Linux (constants) |
| `X-LI-Track` | the real `clientVersion` and display dimensions (macOS) |
| Cookies | issued to Chrome 151 / macOS |

LinkedIn appears to treat that contradiction as a stolen session: it replies with a redirect setting `li_at` to `"delete me"`, which trips `ErrTokenInvalidated` in `checkHTTPRedirect`, and `onBadCredentials` then calls `Cookies.Clear()`.

The user-visible result is a bridge that connects, works for a few seconds, and then 401s every voyager call — `createMessage`, `messengerMessages`, `messengerConversations` — until they log in again, at which point it repeats. An already-established `/realtime/connect` socket survives, so the bridge still reports `connected` and new inbound events keep arriving, which makes it look healthier than it is.

This looks like the same underlying issue as #55 ("`li_at` cookie was deleted", and that reporter's earlier "near-immediate logouts").

### Change

Capture the `User-Agent` request header during cookie login, alongside the headers already captured, store it in `UserLoginMetadata`, and send it on subsequent requests. `sec-ch-ua` and `sec-ch-ua-platform` are derived from it rather than stored separately, so the identity stays internally consistent — sending a stored user agent next to unchanged client hints would be a *stronger* mismatch than not overriding at all.

### Compatibility

The login field is `Required: false` and the derivation is best-effort:

- field absent (existing logins, non-browser flows) → constants, i.e. current behaviour
- user agent not recognisably Chromium → constants, plus a warning; the helper returns `ok=false` rather than emitting a half-populated hint set

No migration needed; stored logins keep working and pick up the new behaviour when they next log in.

### Testing

`go build ./...`, `go vet ./...` and `go test ./pkg/...` all pass. Added a table-driven test for the user-agent parsing covering Chrome on macOS/Linux/Windows, a non-Chromium agent, and the empty string.

Tested on a real account against a Beeper-hosted setup: before the change, each login survived ~20 seconds before `li_at` was deleted and every voyager call 401'd; after it, sending, sync and backfill all work, with no `li_at` deletion. Notably, the cookies were taken from the everyday browser and **that browser session was not logged out**, which previously happened within seconds. Full logs, the confirmation that the field is stored, and instructions for running a self-compiled bridge under `bbctl` are in the comment below.

This is one account observed over minutes rather than weeks, and LinkedIn's side is not directly observable, so I'd describe it as a strong correlation with a plausible mechanism rather than proof.

Note for testers: existing logins won't pick this up, since the user agent is captured at login. A fresh `logout` + `login` is needed.

Refs #55
