### PR TITLE
Stop bare URLs doubling in LinkedIn messages

### DIFF
--- a/pkg/connector/matrixfmt/html.go
+++ b/pkg/connector/matrixfmt/html.go
@@ -327,6 +327,9 @@ func (parser *HTMLParser) linkToString(node *html.Node, ctx Context) *EntityStri
 			return NewEntityString("@" + username).Format(linkedinfmt.Mention{UserID: userID})
 		}
 	}
+	if string(str.String) == href {
+		return str
+	}
 	return ent.AppendString(fmt.Sprintf(" (%s)", href))
 }
 


### PR DESCRIPTION
## What's wrong

Sharing a URL from Beeper into a LinkedIn DM comes out doubled for the recipient: `https://cal.com/meet-edo/coffee-hb (https://cal.com/meet-edo/coffee-hb)`.

The desktop composer linkifies bare URLs into an anchor whose text and href are the same string. Since 4cdd193 dropped LinkedIn's broken hyperlink attributes in favor of plain-text `text (href)`, `linkToString` appends the parenthesized href unconditionally. mautrix-signal's version of the same parser skips it when the text already is the href — this copy lost that check.

## The fix

Return the link text alone when it equals the href. Same check as mautrix-signal's matrixfmt.

## What I checked

- Ran the parser locally against the reported input: `<a href="URL">URL</a>` produced exactly the reported `URL (URL)` before the fix and a single `URL` after. Named links keep the ` (href)` suffix. No tests added.
- `go build -tags goolm ./...` passes. Did not run the bridge against live LinkedIn.
